### PR TITLE
Make Number struct internals public

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -18,12 +18,12 @@ pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 /// Represents a JSON number, whether integer or floating point.
 #[derive(Clone, Eq, PartialEq)]
 pub struct Number {
-    n: N,
+    pub n: N,
 }
 
 #[cfg(not(feature = "arbitrary_precision"))]
 #[derive(Copy, Clone, PartialEq)]
-enum N {
+pub enum N {
     PosInt(u64),
     /// Always less than zero.
     NegInt(i64),


### PR DESCRIPTION
Currently writing a converter from `serde_json::Value` to `unqlite::document::Value`.
However, internal `n` couldn't be accessed.
```
serde_json::Value::Number(n) => todo!(),
```